### PR TITLE
adding aws_session_token to config

### DIFF
--- a/sample-config.json
+++ b/sample-config.json
@@ -12,6 +12,7 @@
         "aws": {
             "aws_access_key_id": "test",
             "aws_secret_access_key": "test",
+            "aws_session_token": "test",
             "aws_region": "us-west-2",
             "aws_profile_name": "test-profile",
             "aws_bucket": "test-bucket",

--- a/target_s3/formats/format_base.py
+++ b/target_s3/formats/format_base.py
@@ -58,6 +58,7 @@ class FormatBase(metaclass=ABCMeta):
             self.session = Session(
                 aws_access_key_id=aws_config.get("aws_access_key_id", None),
                 aws_secret_access_key=aws_config.get("aws_secret_access_key", None),
+                aws_session_token=aws_config.get("aws_session_token", None),
                 region_name=aws_config.get("aws_region"),
                 profile_name=aws_config.get("aws_profile_name", None),
             )

--- a/target_s3/target.py
+++ b/target_s3/target.py
@@ -78,6 +78,12 @@ class Targets3(Target):
                             secret=True,
                         ),
                         th.Property(
+                            "aws_session_token",
+                            th.StringType,
+                            required=False,
+                            secret=True,
+                        ),
+                        th.Property(
                             "aws_region",
                             th.StringType,
                             required=True,


### PR DESCRIPTION
This is to add `aws_session_token` to the boto3.Session, in case might be required