### PR TITLE
updated validate method to handle list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "target-s3"
-version = "1.0.1"
+version = "1.0.3"
 description = "`target-s3` is a Singer target for s3, built with the Meltano Singer SDK."
 authors = ["crowemi"]
 keywords = [


### PR DESCRIPTION
Updated validate method to handle lists. 

An error was occurring  when list contained elements of mixed type. e.g. [0,1,2] and ["0", 1, 2] - this would result in pyarrow failing to create table.

`pyarrow.lib.ArrowInvalid: Could not convert '0' with type str: tried to convert to int64`
