### PR TITLE
added parquet schema generation from tap

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -1,25 +1,61 @@
 version: 1
 send_anonymous_usage_stats: false
-project_id: "target-s3"
+project_id: target-s3
 default_environment: test
 environments:
-  - name: test
+- name: test
 plugins:
   extractors: []
   loaders:
-    - name: "target-s3"
-      namespace: "target_s3"
-      pip_url: -e .
-      capabilities:
-        - about
-        - stream-maps
-        - record-flattening
-      config:
-        start_date: "2010-01-01T00:00:00Z"
-      settings:
-        # TODO: To configure using Meltano, declare settings and their types here:
-        - name: username
-        - name: password
-          kind: password
-        - name: start_date
-          value: "2010-01-01T00:00:00Z"
+  - name: target-s3
+    namespace: target_s3
+    pip_url: -e .
+    capabilities:
+    - about
+    - stream-maps
+    - record-flattening
+    settings:
+    - name: format.format_type
+    - name: format.format_parquet.validate
+      kind: boolean
+      value: false
+    - name: format.format_parquet.get_schema_from_tap
+      kind: boolean
+      value: false
+    - name: cloud_provider.cloud_provider_type
+      value: aws
+    - name: cloud_provider.aws.aws_access_key_id
+      kind: password
+    - name: cloud_provider.aws.aws_secret_access_key
+      kind: password
+    - name: cloud_provider.aws.aws_session_token
+      kind: password
+    - name: cloud_provider.aws.aws_region
+      kind: password
+    - name: cloud_provider.aws.aws_profile_name
+      kind: password
+    - name: cloud_provider.aws.aws_bucket
+      kind: password
+    - name: cloud_provider.aws.aws_endpoint_override
+    - name: prefix
+    - name: stream_name_path_override
+    - name: include_process_date
+      kind: boolean
+      value: false
+    - name: append_date_to_prefix
+      kind: boolean
+      value: true
+    - name: partition_name_enabled
+      kind: boolean
+      value: false
+    - name: append_date_to_prefix_grain
+      value: day
+    - name: append_date_to_filename
+      kind: boolean
+      value: true
+    - name: append_date_to_filename_grain
+      value: microsecond
+    - name: flatten_records
+      kind: boolean
+      value: false
+

--- a/target_s3/formats/format_base.py
+++ b/target_s3/formats/format_base.py
@@ -117,23 +117,55 @@ class FormatBase(metaclass=ABCMeta):
             grain = DATE_GRAIN[self.config["append_date_to_prefix_grain"].lower()]
             partition_name_enabled = False
             if self.config["partition_name_enabled"]:
-                partition_name_enabled = self.config["partition_name_enabled"]   
-            folder_path += self.create_folder_structure(batch_start, grain, partition_name_enabled)
+                partition_name_enabled = self.config["partition_name_enabled"]
+            folder_path += self.create_folder_structure(
+                batch_start, grain, partition_name_enabled
+            )
         if self.config["append_date_to_filename"]:
             grain = DATE_GRAIN[self.config["append_date_to_filename_grain"].lower()]
             file_name += f"{self.create_file_structure(batch_start, grain)}"
 
         return f"{folder_path}{file_name}"
 
-    def create_folder_structure(self, batch_start: datetime, grain: int, partition_name_enabled: bool) -> str:
+    def create_folder_structure(
+        self, batch_start: datetime, grain: int, partition_name_enabled: bool
+    ) -> str:
         ret = ""
-        ret += f"{'year=' if partition_name_enabled        else  ''}{batch_start.year}/" if grain <= DATE_GRAIN["year"] else ""
-        ret += f"{'month=' if partition_name_enabled       else  ''}{batch_start.month:02}/" if grain <= DATE_GRAIN["month"] else ""
-        ret += f"{'day=' if partition_name_enabled         else  ''}{batch_start.day:02}/" if grain <= DATE_GRAIN["day"] else ""
-        ret += f"{'hour=' if partition_name_enabled        else  ''}{batch_start.hour:02}/" if grain <= DATE_GRAIN["hour"] else ""
-        ret += f"{'minute=' if partition_name_enabled      else  ''}{batch_start.minute:02}/" if grain <= DATE_GRAIN["minute"] else ""
-        ret += f"{'second=' if partition_name_enabled      else  ''}{batch_start.second:02}/" if grain <= DATE_GRAIN["second"] else ""
-        ret += f"{'microsecond=' if partition_name_enabled else  ''}{batch_start.microsecond}/" if grain <= DATE_GRAIN["microsecond"] else ""
+        ret += (
+            f"{'year=' if partition_name_enabled        else  ''}{batch_start.year}/"
+            if grain <= DATE_GRAIN["year"]
+            else ""
+        )
+        ret += (
+            f"{'month=' if partition_name_enabled       else  ''}{batch_start.month:02}/"
+            if grain <= DATE_GRAIN["month"]
+            else ""
+        )
+        ret += (
+            f"{'day=' if partition_name_enabled         else  ''}{batch_start.day:02}/"
+            if grain <= DATE_GRAIN["day"]
+            else ""
+        )
+        ret += (
+            f"{'hour=' if partition_name_enabled        else  ''}{batch_start.hour:02}/"
+            if grain <= DATE_GRAIN["hour"]
+            else ""
+        )
+        ret += (
+            f"{'minute=' if partition_name_enabled      else  ''}{batch_start.minute:02}/"
+            if grain <= DATE_GRAIN["minute"]
+            else ""
+        )
+        ret += (
+            f"{'second=' if partition_name_enabled      else  ''}{batch_start.second:02}/"
+            if grain <= DATE_GRAIN["second"]
+            else ""
+        )
+        ret += (
+            f"{'microsecond=' if partition_name_enabled else  ''}{batch_start.microsecond}/"
+            if grain <= DATE_GRAIN["microsecond"]
+            else ""
+        )
         return ret
 
     def create_file_structure(self, batch_start: datetime, grain: int) -> str:
@@ -144,7 +176,9 @@ class FormatBase(metaclass=ABCMeta):
         ret += f"-{batch_start.hour:02}" if grain <= DATE_GRAIN["hour"] else ""
         ret += f"{batch_start.minute:02}" if grain <= DATE_GRAIN["minute"] else ""
         ret += f"{batch_start.second:02}" if grain <= DATE_GRAIN["second"] else ""
-        ret += f"{batch_start.microsecond}" if grain <= DATE_GRAIN["microsecond"] else ""
+        ret += (
+            f"{batch_start.microsecond}" if grain <= DATE_GRAIN["microsecond"] else ""
+        )
         return ret
 
     def flatten_key(self, k, parent_key, sep) -> str:

--- a/target_s3/sinks.py
+++ b/target_s3/sinks.py
@@ -30,6 +30,7 @@ class s3Sink(BatchSink):
         super().__init__(target, stream_name, schema, key_properties)
         # what type of file are we building?
         self.format_type = self.config.get("format", None).get("format_type", None)
+        self.schema = schema
         if self.format_type:
             if self.format_type not in FORMAT_TYPE:
                 raise Exception(
@@ -43,6 +44,7 @@ class s3Sink(BatchSink):
         # add stream name to context
         context["stream_name"] = self.stream_name
         context["logger"] = self.logger
+        context["batch_schema"] = self.schema
         # creates new object for each batch
         format_type_client = format_type_factory(
             FORMAT_TYPE[self.format_type], self.config, context

--- a/target_s3/sinks.py
+++ b/target_s3/sinks.py
@@ -44,7 +44,7 @@ class s3Sink(BatchSink):
         # add stream name to context
         context["stream_name"] = self.stream_name
         context["logger"] = self.logger
-        context["batch_schema"] = self.schema
+        context["stream_schema"] = self.schema
         # creates new object for each batch
         format_type_client = format_type_factory(
             FORMAT_TYPE[self.format_type], self.config, context

--- a/target_s3/target.py
+++ b/target_s3/target.py
@@ -1,6 +1,8 @@
 """s3 target class."""
 
 from __future__ import annotations
+import decimal
+import json
 
 from singer_sdk.target_base import Target
 from singer_sdk import typing as th
@@ -47,7 +49,7 @@ class Targets3(Target):
                                          resulting parquet file based on taps. Doesn't \
                                          work with 'anyOf' types or when complex data is\
                                          not defined at element level. Doesn't work with \
-                                         validate option for now."
+                                         validate option for now.",
                         ),
                     ),
                     required=False,

--- a/target_s3/target.py
+++ b/target_s3/target.py
@@ -38,6 +38,17 @@ class Targets3(Target):
                             required=False,
                             default=False,
                         ),
+                        th.Property(
+                            "get_schema_from_tap",
+                            th.BooleanType,
+                            required=False,
+                            default=False,
+                            description="Set true if you want to declare schema of the\
+                                         resulting parquet file based on taps. Doesn't \
+                                         work with 'anyOf' types or when complex data is\
+                                         not defined at element level. Doesn't work with \
+                                         validate option for now."
+                        ),
                     ),
                     required=False,
                 ),
@@ -164,6 +175,28 @@ class Targets3(Target):
     ).to_dict()
 
     default_sink_class = s3Sink
+
+    def deserialize_json(self, line: str) -> dict:
+        """Override base target's method to overcome Decimal cast,
+        only applied when generating parquet schema from tap schema.
+
+        :param line: serialized record from stream
+        :type line: str
+        :return: deserialized record
+        :rtype: dict
+        """
+        try:
+            self.format = self.config.get("format", None)
+            format_parquet = self.format.get("format_parquet", None)
+            if format_parquet and format_parquet.get("get_schema_from_tap", False):
+                return json.loads(line)  # type: ignore[no-any-return]
+            else:
+                return json.loads(  # type: ignore[no-any-return]
+                    line, parse_float=decimal.Decimal
+                )
+        except json.decoder.JSONDecodeError as exc:
+            self.logger.error("Unable to parse:\n%s", line, exc_info=exc)
+            raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#23, #17 

This branch adds the functionality of generating schema from schema message generated from tap.

Known Limitations:
- Doesn't work for "types" like `anyOf` where there is a clear mix of incompatible data types.
- Doesn't work if the complex data type like `array` or `object` has not been defined initially in the tap. (empty structs raise exception, this is handled in the implementation by giving warning and raising error when storing parquet file)

Future work:
- handling nullable property better, right now everything is nullable by default.