### PR TITLE
Fix the max_batch_size parameter usage

### DIFF
--- a/target_s3/sinks.py
+++ b/target_s3/sinks.py
@@ -44,7 +44,7 @@ class s3Sink(BatchSink):
         Returns:
             Maximum batch size
         """
-        return self.config.get("batch_size", 10000)
+        return self.config.get("max_batch_size", 10000)
 
     def process_batch(self, context: dict) -> None:
         """Write out any prepped records and return once fully written."""


### PR DESCRIPTION
This fixes the `MAX_BATCH_SIZE` parameter usage : currently it doesn't work with `max_batch_size` but requires to provide a `batch_size` parameter, which is not what is documented.
Tested with Parquet writer.