### PR TITLE
fix: corrected bad datetime json encoding when selecting jsonl format

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2392,8 +2392,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-<<<<<<< HEAD
 content-hash = "64bc9d0b597b6c5a88a7831f22dceb9a01c3ffd7c67c576ca094af786fd7f2a3"
-=======
-content-hash = "9628835cec18fe8f2f77e9980d1052b2bc93e39ae05f92d7f8810fe5d1357702"
->>>>>>> 8310ed963d58a9e62799238a54c3c318ce61400b

--- a/target_s3/formats/format_jsonl.py
+++ b/target_s3/formats/format_jsonl.py
@@ -1,19 +1,12 @@
-from datetime import datetime
+from functools import partial
 
-from bson import ObjectId
-from simplejson import JSONEncoder, dumps
+import simplejson as json
 
 from target_s3.formats.format_base import FormatBase
 
+from .format_json import JsonSerialize
 
-class JsonSerialize(JSONEncoder):
-    def default(self, obj: any) -> any:
-        if isinstance(obj, ObjectId):
-            return str(obj)
-        if isinstance(obj, datetime):
-            return obj.isoformat()
-        else:
-            raise TypeError(f"Type {type(obj)} not serializable")
+dumps = partial(json.dumps, cls=JsonSerialize)
 
 
 class FormatJsonl(FormatBase):
@@ -26,7 +19,7 @@ class FormatJsonl(FormatBase):
         return super()._prepare_records()
 
     def _write(self) -> None:
-        return super()._write('\n'.join(map(dumps, self.records)))
+        return super()._write("\n".join(map(dumps, self.records)))
 
     def run(self) -> None:
         # use default behavior, no additional run steps needed


### PR DESCRIPTION
This is a small patch to apply the correct serializer for `jsonl` as for json. It encountered it while evaluating this target:
The `poetry.lock` file was also incorrect. Cheers :beer: 
```
2024-06-19T16:26:04.795208Z [info     ] TypeError: Object of type datetime is not JSON serializable cmd_type=elb consumer=True job_name=dev:tap-postgres-to-target-s3 name=target-s3 producer=False run_id=90af8632-26c9-450c-a2e3-69d587253194 stdio=stderr string_id=target-s3
2024-06-19T16:26:04.917234Z [error    ]                               
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /home/drnick/repos/drnick/ingester-playground/.venv/lib/python3.10/site-packages/meltano/core/lo │
│ gging/output_logger.py:208 in redirect_logging                                                   │
│                                                                                                  │
│   205 │   │   │   *ignore_errors,                                                                │
│   206 │   │   )                                                                                  │
│   207 │   │   try:                                                                               │
│ ❱ 208 │   │   │   yield                                                                          │
│   209 │   │   except ignored_errors:  # noqa: WPS329                                             │
│   210 │   │   │   raise                                                                          │
│   211 │   │   except RunnerError as err:                                                         │
│                                                                                                  │
```