### PR TITLE
add partition_by property list

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,17 @@ Build with the [Meltano Target SDK](https://sdk.meltano.com).
     "flattening_enabled": true|false,
     "flattening_max_depth": int,
     "max_batch_age": int,
-    "max_batch_size": int
+    "max_batch_size": int,
+    "partition_by": ["tenant=${TENANT}", "dt=${CURRENT_DATE_MINUTE_LEVEL}"]
 }
 ```
 `format.format_parquet.validate` [`Boolean`, default: `False`] - this flag determines whether the data types of incoming data elements should be validated. When set `True`, a schema is created from the first record and all subsequent records that don't match that data type are cast.
+
+- `partition_by` [`Array[String]`, optional]: List of key-value strings (e.g., 'tenant=${TENANT}') to be inserted as partition folders **after the stream name** in the S3 key path. For example, if `partition_by: ['tenant=${TENANT}', 'dt=${CURRENT_DATE_MINUTE_LEVEL}']` and the stream is `Account`, the S3 key will look like:
+
+  ```
+  bucket/prefix/Account/tenant=${TENANT}/dt=${CURRENT_DATE_MINUTE_LEVEL}/...
+  ```
 
 ## Capabilities
 

--- a/target_s3/formats/format_base.py
+++ b/target_s3/formats/format_base.py
@@ -49,6 +49,7 @@ class FormatBase(metaclass=ABCMeta):
         self.compression = "gz"  # TODO: need a list of compatible compression types
 
         self.stream_name_path_override = config.get("stream_name_path_override", None)
+        self.partition_by = config.get("partition_by", [])
 
         if self.cloud_provider.get("cloud_provider_type", None) == "aws":
             aws_config = self.cloud_provider.get("aws", None)
@@ -111,7 +112,12 @@ class FormatBase(metaclass=ABCMeta):
             if self.stream_name_path_override is None
             else self.stream_name_path_override
         )
-        folder_path = f"{self.bucket}/{self.prefix}/{stream_name}/"
+        # Insert partition_by values after stream_name if present
+        partition_path = ""
+        if self.partition_by:
+            # partition_by values are inserted as folders after the stream name
+            partition_path = "/".join(self.partition_by) + "/"
+        folder_path = f"{self.bucket}/{self.prefix}/{stream_name}/" + partition_path
         file_name = ""
         if self.config["append_date_to_prefix"]:
             grain = DATE_GRAIN[self.config["append_date_to_prefix_grain"].lower()]

--- a/target_s3/target.py
+++ b/target_s3/target.py
@@ -190,6 +190,12 @@ class Targets3(Target):
             required=False,
             default=10000,
         ),
+        th.Property(
+            "partition_by",
+            th.ArrayType(th.StringType),
+            required=False,
+            description="List of key-value strings (e.g., 'tenant=${TENANT}') to prepend as partitions in the S3 key path after the stream name.",
+        ),
     ).to_dict()
 
     default_sink_class = s3Sink


### PR DESCRIPTION
## Feature: Add `partition_by` Configuration for Flexible S3 Partitioning

### Summary

This PR introduces a new configuration option, `partition_by`, to the `target-s3` Singer target. This option allows users to specify a list of key-value strings (e.g., `tenant=${TENANT}`) that are inserted as partition folders **after the stream name** in the S3 key path. This enables more flexible and organized partitioning of data in S3 for downstream analytics and data management.

### Changes

- **New Config Option:**  
  - `partition_by` (`Array[String]`, optional): List of key-value strings to be inserted as partition folders after the stream name in the S3 key path.
  - Example:  
    If `partition_by: ['tenant=${TENANT}', 'dt=${CURRENT_DATE_MINUTE_LEVEL}']` and the stream is `Account`, the S3 key will look like:
    ```
    bucket/prefix/Account/tenant=${TENANT}/dt=${CURRENT_DATE_MINUTE_LEVEL}/...
    ```

- **Documentation:**
  - Updated `README.md` to include the new option, with usage and example.
  - Added inline code comments and docstrings to clarify the effect and usage of `partition_by`.

### Motivation

- Enables more granular and customizable S3 partitioning, which is especially useful for large-scale data lakes and downstream analytics.
- Improves maintainability and clarity for both users and contributors.

### Checklist

- [x] Code changes
- [x] Documentation updates
- [x] Inline comments and docstrings