### PR TITLE
fix : datetime is not json serializable    

### DIFF
--- a/target_s3/formats/format_jsonl.py
+++ b/target_s3/formats/format_jsonl.py
@@ -26,7 +26,11 @@ class FormatJsonl(FormatBase):
         return super()._prepare_records()
 
     def _write(self) -> None:
-        return super()._write('\n'.join(map(dumps, self.records)))
+        return super()._write(
+            "\n".join(
+                map(lambda record: dumps(record, cls=JsonSerialize), self.records)
+            )
+        )
 
     def run(self) -> None:
         # use default behavior, no additional run steps needed


### PR DESCRIPTION
On selecting jsonl as target type

- All datetime type schema properties were failing with the error (datetime is not JSON serializable).
- You can simply enable the config include_process_date, and this error will appear with format_type: jsonl.
- Added custom JSON serializer which is already used to fix issue https://github.com/crowemi/target-s3/issues/1